### PR TITLE
Implement simple shapely-based SVG packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 This project provides a Python-based command line interface for a simple SVG nesting example.
 
 The original JavaScript implementation is kept in the `old/` directory.
+
+## Usage
+
+Install the package (Poetry is recommended):
+
+```bash
+poetry install
+```
+
+To pack all SVGs inside `data/raw` and write a combined SVG to `output/nested.svg` run:
+
+```bash
+poetry run python main.py nest
+```
+
+The packing algorithm is implemented in `src/placer.py` using `shapely`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ packages = [{ include = "src" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 fire = "^0.5"
+shapely = "^2.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/geometry.py
+++ b/src/geometry.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from xml.etree import ElementTree as ET
+from shapely.geometry import box, Polygon
+
+
+def polygon_from_svg(path: Path) -> Polygon:
+    """Return a simple bounding box polygon for the SVG viewBox."""
+    root = ET.parse(path).getroot()
+    viewbox = root.get('viewBox')
+    if viewbox:
+        parts = [float(v) for v in viewbox.replace(',', ' ').split()]
+        if len(parts) == 4:
+            x, y, w, h = parts
+            return box(x, y, x + w, y + h)
+    width = root.get('width')
+    height = root.get('height')
+    if width and height:
+        w = float(width)
+        h = float(height)
+        return box(0, 0, w, h)
+    raise ValueError(f"Cannot determine bounds for {path}")

--- a/src/nest.py
+++ b/src/nest.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 from .paths import Paths
-from .svg import combine_svgs, save_svg
+from .svg import save_svg
+from .placer import pack_svgs
 
 
 def nest(paths: Paths) -> Path:
     paths.ensure()
     svg_files = sorted(paths.raw.glob('*.svg'))
-    combined = combine_svgs(svg_files)
+    combined = pack_svgs(svg_files)
     output_file = paths.output / 'nested.svg'
     save_svg(combined, output_file)
     return output_file

--- a/src/placer.py
+++ b/src/placer.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import Iterable, Tuple
+from xml.etree import ElementTree as ET
+
+from shapely.affinity import translate
+from shapely.geometry import Polygon
+
+from .svg import load_svg
+from .geometry import polygon_from_svg
+
+
+def pack_svgs(paths: Iterable[Path], spacing: float = 10.0, bin_width: float = 1000.0) -> ET.Element:
+    """Pack multiple SVGs into a single SVG document."""
+    placed: list[Tuple[ET.Element, float, float, Polygon]] = []
+    x_cursor = 0.0
+    y_cursor = 0.0
+    row_height = 0.0
+    for path in paths:
+        svg = load_svg(path)
+        poly = polygon_from_svg(path)
+        width = poly.bounds[2] - poly.bounds[0]
+        height = poly.bounds[3] - poly.bounds[1]
+        if x_cursor + width > bin_width:
+            x_cursor = 0.0
+            y_cursor += row_height + spacing
+            row_height = 0.0
+        placed_poly = translate(poly, xoff=x_cursor, yoff=y_cursor)
+        placed.append((svg, x_cursor, y_cursor, placed_poly))
+        x_cursor += width + spacing
+        row_height = max(row_height, height)
+    root = ET.Element('svg', xmlns='http://www.w3.org/2000/svg')
+    group = ET.SubElement(root, 'g')
+    union_poly: Polygon | None = None
+    for svg, x, y, poly in placed:
+        g = ET.SubElement(group, 'g', transform=f'translate({x},{y})')
+        g.extend(list(svg))
+        if union_poly is None:
+            union_poly = poly
+        else:
+            union_poly = union_poly.union(poly)
+    if union_poly is not None:
+        total_width = union_poly.bounds[2] - union_poly.bounds[0]
+        total_height = union_poly.bounds[3] - union_poly.bounds[1]
+        ET.SubElement(root, 'rect', width=str(total_width), height=str(total_height),
+                     fill='none', stroke='black')
+    return root

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from src.geometry import polygon_from_svg
+from src.placer import pack_svgs
+
+
+def _create_svg(path: Path, size: int) -> None:
+    svg = ET.Element('svg', viewBox=f"0 0 {size} {size}")
+    ET.SubElement(svg, 'rect', width=str(size), height=str(size))
+    path.write_text(ET.tostring(svg, encoding='unicode'))
+
+
+def test_polygon_from_svg(tmp_path: Path):
+    f = tmp_path / 'a.svg'
+    _create_svg(f, 10)
+    poly = polygon_from_svg(f)
+    assert poly.bounds == (0.0, 0.0, 10.0, 10.0)
+
+
+def test_pack_svgs(tmp_path: Path):
+    f1 = tmp_path / 'a.svg'
+    f2 = tmp_path / 'b.svg'
+    _create_svg(f1, 10)
+    _create_svg(f2, 20)
+    result = pack_svgs([f1, f2], spacing=5.0, bin_width=50.0)
+    # ensure resulting SVG has two groups with transforms
+    groups = [g for g in result.findall('.//g') if 'transform' in g.attrib]
+    assert len(groups) == 2


### PR DESCRIPTION
## Summary
- add shapely as dependency and pytest for tests
- implement geometry helper to extract polygon bounds
- implement placer module packing SVGs using shapely
- replace placeholder in `nest.py` with new packer
- document usage in README
- add basic unit tests

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'shapely')*

------
https://chatgpt.com/codex/tasks/task_e_68496d85005c8324a7f507c02378a127