### PR TITLE
Fix bounding box for nested SVG output

### DIFF
--- a/src/nest.py
+++ b/src/nest.py
@@ -11,25 +11,17 @@ def nest(paths: Paths) -> Path:
     # pack 25 copies of each SVG present in the raw folder
     svg_files = [p for p in svg_files for _ in range(25)]
     combined = pack_svgs_ga(svg_files, bin_width=1000.0)
-    rect = combined.find('rect')
-    root_width = '1000'
-    root_height = '500'
+    # `pack_svgs_ga` already sets the appropriate bounding rectangle and
+    # dimensions on the returned SVG element.  Simply propagate those values
+    # to ensure the canvas fits all nested shapes.
+    rect = combined.find("rect")
     if rect is not None:
-        rect.set('width', root_width)
-        rect.set('height', root_height)
-    else:
-        ET.SubElement(
-            combined,
-            'rect',
-            width=root_width,
-            height=root_height,
-            fill='none',
-            stroke='black',
-        )
-    # ensure the svg element itself reflects the final canvas size
-    combined.set('width', root_width)
-    combined.set('height', root_height)
-    combined.set('viewBox', f"0 0 {root_width} {root_height}")
+        width = rect.get("width")
+        height = rect.get("height")
+        if width is not None and height is not None:
+            combined.set("width", width)
+            combined.set("height", height)
+            combined.set("viewBox", f"0 0 {width} {height}")
     output_file = paths.output / 'nested.svg'
     save_svg(combined, output_file)
     return output_file


### PR DESCRIPTION
## Summary
- respect the automatically computed bounds from `pack_svgs_ga`
- update the generated SVG dimensions to avoid clipping nested shapes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849869868388324b1ceb1329620bbf1