### PR TITLE
Fix rotation transform order

### DIFF
--- a/src/placer.py
+++ b/src/placer.py
@@ -35,8 +35,7 @@ def pack_svgs(
     for path, angle in zip(paths_iter, rotations_list):
         svg = load_svg(path)
         poly = polygon_from_svg(path)
-        minx, miny, maxx, maxy = poly.bounds
-        poly = rotate(poly, angle, origin="center")
+        poly = rotate(poly, angle)
         offx, offy, maxx_r, maxy_r = poly.bounds
         poly = translate(poly, xoff=-offx, yoff=-offy)
         width = maxx_r - offx
@@ -56,7 +55,7 @@ def pack_svgs(
     group = ET.SubElement(root, 'g', **group_attrib)
     union_poly: Polygon | None = None
     for svg, x, y, angle, poly in placed:
-        g = ET.SubElement(group, 'g', transform=f'translate({x},{y}) rotate({angle})')
+        g = ET.SubElement(group, 'g', transform=f'rotate({angle}) translate({x},{y})')
         g.extend(list(svg))
         if union_poly is None:
             union_poly = poly

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -106,4 +106,17 @@ def test_offset_shapes_transforms(tmp_path: Path):
     result = pack_svgs([f1, f2], spacing=5.0, bin_width=100.0)
     groups = [g for g in result.findall('.//g') if 'transform' in g.attrib]
     assert len(groups) == 2
-    assert groups[0].get('transform', '').startswith('translate(-50')
+    t0 = groups[0].get('transform', '')
+    assert t0.startswith('rotate(')
+    assert 'translate(-50' in t0
+
+
+def test_rotation_transform_order(tmp_path: Path):
+    f1 = tmp_path / 'a.svg'
+    f2 = tmp_path / 'b.svg'
+    _create_svg(f1, 10)
+    _create_svg(f2, 10)
+    result = pack_svgs([f1, f2], spacing=1.0, bin_width=100.0, rotations=[45.0, 0.0])
+    groups = [g for g in result.findall('.//g') if 'transform' in g.attrib]
+    assert groups[0].get('transform', '').startswith('rotate(45')
+    assert 'translate(' in groups[0].get('transform', '')


### PR DESCRIPTION
## Summary
- rotate polygons around the origin in the placer
- apply rotation before translation when emitting SVG groups
- update tests for new transform order
- cover rotation order with an additional test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499615dee48324aa946e29edfebfd3