### PR TITLE
Fix svg-path-commander build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,17 +6,18 @@
   "type": "commonjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "browserify svgnest.js -o dist/svgnest.bundle.js && browserify util/placementworker.js -o dist/placementworker.bundle.js && browserify svgparser.js -o dist/svgparser.bundle.js"
+    "build": "browserify svgnest.js -p esmify -o dist/svgnest.bundle.js && browserify util/placementworker.js -p esmify -o dist/placementworker.bundle.js && browserify svgparser.js -p esmify -o dist/svgparser.bundle.js"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
     "@doodle3d/clipper-lib": "^6.4.2-b",
     "paralleljs": "^1.1.0",
-    "svg-path-commander": "^2.8.1"
+    "svg-path-commander": "^2.1.11"
   },
   "devDependencies": {
-    "browserify": "^17.0.0"
+    "browserify": "^17.0.0",
+    "esmify": "^2.1.1"
   },
   "packageManager": "pnpm@10.5.2"
 }


### PR DESCRIPTION
## Summary
- support ES modules when bundling with Browserify
- pin svg-path-commander to v2.1.11

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: browserify not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a155608b88324ab3fb484c68154b9